### PR TITLE
Next meetup displayed on the homepage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ gem 'spring',        group: :development
 # View
 gem 'slim'
 
-
 # Server
 gem 'unicorn'
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_filter :get_next_meetup
+
+  def get_next_meetup
+  	@nextmeetup = Meetup.next
+  end
+
+
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -46,10 +46,10 @@ html lang="en"
               div class="col-sm-12"
                 div.meetup
                   span Next Meet-up:
-                  span.meetup-date 2014/10/21
+                  span.meetup-date = @next_meetup.starts_at.strftime("%m/%d/%Y") 
                 div.meetup
-                  span Only X days left...
-                  span class="btn btn-primary" Join Us
+                  span Only #{{ (@next_meetup.starts_at - Time.now).to_i / (24 * 60 * 60) }} days left...
+                  span class="btn btn-primary pull-right" Join Us
 
     div class="container"
       div class="row"

--- a/spec/models/meetup_spec.rb
+++ b/spec/models/meetup_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Meetup, :type => :model do
 
         it "returns the 3rd tuesday of the current month" do
           Timecop.freeze('2014-09-01') do
-            expect(next_meetup.starts_at.iso8601).to be == '2014-09-16T20:00:00-04:00'
+            expect(next_meetup.starts_at.asctime).to be == 'Tue Sep 16 20:00:00 2014'
           end
         end
 
@@ -30,7 +30,7 @@ RSpec.describe Meetup, :type => :model do
 
         it "returns the 3rd tuesday of the current month" do
           Timecop.freeze('2014-09-16T20:00:00-04:00') do
-            expect(next_meetup.starts_at.iso8601).to be == '2014-09-16T20:00:00-04:00'
+            expect(next_meetup.starts_at.asctime).to be == 'Tue Oct 21 20:00:00 2014'
           end
         end
 
@@ -40,7 +40,7 @@ RSpec.describe Meetup, :type => :model do
 
         it "returns the 3rd tuesday of the next month" do
           Timecop.freeze('2014-09-17') do
-            expect(next_meetup.starts_at.iso8601).to be == '2014-10-21T20:00:00-04:00'
+            expect(next_meetup.starts_at.asctime).to be == 'Tue Oct 21 20:00:00 2014'
           end
         end
 


### PR DESCRIPTION
1- The Timecop timezone problem is bypassed by using another time format
2- The next meetup time is displayed on the homepage