### PR TITLE
refactored news_item to remove #published?

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -1,15 +1,10 @@
 class NewsItem < ActiveRecord::Base
   extend Enumerize
   enumerize :state, in: [:draft, :archived, :published]
-  validates :published_at, presence: true, if: :published?
+  validates :published_at, presence: true, if: lambda{ state.published? } 
   validates_presence_of :title, :state
 
   def self.published
     where(state: "published").order(:published_at)
-  end
-
-  def published?
-    return true if state == "published"
-    false
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -2,6 +2,6 @@ class NewsItem < ActiveRecord::Base
   extend Enumerize
   enumerize :state, in: [:draft, :archived, :published]
   scope :published, -> { where(state: :published).order(:published_at) }
-  validates :published_at, presence: true, if: lambda{ state.published? } 
+  validates :published_at, presence: true, if: -> { state.published? } 
   validates_presence_of :title, :state
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -1,10 +1,7 @@
 class NewsItem < ActiveRecord::Base
   extend Enumerize
   enumerize :state, in: [:draft, :archived, :published]
+  scope :published, -> { where(state: :published).order(:published_at) }
   validates :published_at, presence: true, if: lambda{ state.published? } 
   validates_presence_of :title, :state
-
-  def self.published
-    where(state: "published").order(:published_at)
-  end
 end


### PR DESCRIPTION
Used a lambda in the validation felt that it was more concise and slightly cleaner than using a method. Though a could
``` ruby
def published?
  state.published?
end
```
also be used.

@cawel thanks for the tip!