### PR TITLE
Markdown support (phase 1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'turbolinks'
 # View
 gem 'simple_form'
 gem 'enumerize'
+gem 'redcarpet'
 
 # Server
 gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    redcarpet (3.3.3)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rest-client (1.8.0)
@@ -338,6 +339,7 @@ DEPENDENCIES
   pry
   rails (~> 4.2.2)
   rails_12factor
+  redcarpet
   rspec-rails
   sass-rails
   simple_form

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,17 +1,11 @@
 class EventsController < ApplicationController
-  before_action :load_event, only: [:show]
 
   def index
     @events = Event.published
   end
 
   def show
-
+    @event = Event.find(params[:id])
   end
-
-  private
-    def load_event
-      @event = Event.find(params[:id])
-    end
 
 end

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -2,4 +2,8 @@ class NewsItemsController < ApplicationController
   def index
     @news_items = NewsItem.published.to_a
   end
+
+  def show
+    @news_item = NewsItem.find(params[:id])
+  end
 end

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -4,6 +4,6 @@ class NewsItemsController < ApplicationController
   end
 
   def show
-    @news_item = NewsItem.find(params[:id])
+    @news_item = NewsItem.published.find(params[:id])
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -2,4 +2,8 @@ class OrganizationsController < ApplicationController
   def index
     @organizations = Organization.all
   end
+
+  def show
+    @organization = Organization.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,2 @@
 module ApplicationHelper
-  @@renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
-
-  def render_markdown_as_html(markup)
-    raw @@renderer.render(markup)
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  @@renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
+
+  def render_markdown_as_html(markup)
+    raw @@renderer.render(markup)
+  end
 end

--- a/app/helpers/text_helper.rb
+++ b/app/helpers/text_helper.rb
@@ -1,0 +1,7 @@
+module TextHelper
+  @@renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
+
+  def render_markdown_as_html(markup)
+    raw(@@renderer.render(markup))
+  end
+end

--- a/app/helpers/text_helper.rb
+++ b/app/helpers/text_helper.rb
@@ -1,7 +1,11 @@
 module TextHelper
-  @@renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true, tables: true)
+  @renderer = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
+                                      autolink: true, tables: true)
+  class << self
+    attr_reader :renderer
+  end
 
   def render_markdown_as_html(markup)
-    raw(@@renderer.render(markup))
+    raw(TextHelper.renderer.render(markup))
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,1 +1,4 @@
 <h1><%= @event.title %></h1>
+
+<%= render_markdown_as_html(@event.introduction) %>
+<%= render_markdown_as_html(@event.conclusion) %>

--- a/app/views/news_items/show.html.erb
+++ b/app/views/news_items/show.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @news_item.title %></h1>
+
+<%= render_markdown_as_html(@news_item.body) %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,0 +1,3 @@
+<h1><%= @organization.name %></h1>
+
+<%= render_markdown_as_html(@organization.description) %>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -1,5 +1,3 @@
 <h1><%= @page.title %></h1>
 
-<div>
-  <%= @page.body %>
-</div>
+<%= render_markdown_as_html(@page.body) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   resources :events, only: [:index, :show]
-  resources :news_items, :organizations
+  resources :news_items, only: [:index, :show]
 
   root 'home#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
 
   get 'organizations/show'
 
-  resources :pages, except: [:index]
 
   namespace :admin do
     DashboardManifest::DASHBOARDS.each do |dashboard_resource|
@@ -17,6 +16,7 @@ Rails.application.routes.draw do
 
   resources :events, only: [:index, :show]
   resources :news_items, only: [:index, :show]
+  resources :pages, only: [:show]
 
   root 'home#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  resources :events, only:[:index, :show]
+  resources :events, only: [:index, :show]
   resources :news_items, :organizations
 
   root 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  get 'organizations/index'
-
-  get 'organizations/show'
-
 
   namespace :admin do
     DashboardManifest::DASHBOARDS.each do |dashboard_resource|
@@ -16,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :events, only: [:index, :show]
   resources :news_items, only: [:index, :show]
+  resources :organizations, only: [:index, :show]
   resources :pages, only: [:show]
 
   root 'home#index'

--- a/spec/controllers/news_item_controller_spec.rb
+++ b/spec/controllers/news_item_controller_spec.rb
@@ -2,4 +2,26 @@ require 'rails_helper'
 
 RSpec.describe NewsItemsController, type: :controller do
 
+  context 'when accessing a published news_item' do
+    let(:published_news_item) { create :news_item, state: 'published' }
+
+    it 'returns a 200 status code' do
+      get :show, id: published_news_item
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  context 'when accessing a non-published news_item' do
+    let(:draft_news_item) { create :news_item, state: 'draft' }
+    let(:archived_news_item) { create :news_item, state: 'draft' }
+
+    it 'raises a RecordNotFound error' do
+      [draft_news_item, archived_news_item].each do |news_item|
+        expect{
+          get :show, id: news_item
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
 end

--- a/spec/controllers/news_item_controller_spec.rb
+++ b/spec/controllers/news_item_controller_spec.rb
@@ -2,26 +2,25 @@ require 'rails_helper'
 
 RSpec.describe NewsItemsController, type: :controller do
 
-  context 'when accessing a published news_item' do
-    let(:published_news_item) { create :news_item, state: 'published' }
+  context "when accessing a published news_item" do
+    let(:published_news_item) { create :news_item, state: "published" }
 
-    it 'returns a 200 status code' do
+    it "returns a 200 status code" do
       get :show, id: published_news_item
       expect(response).to have_http_status(200)
     end
   end
 
-  context 'when accessing a non-published news_item' do
-    let(:draft_news_item) { create :news_item, state: 'draft' }
-    let(:archived_news_item) { create :news_item, state: 'draft' }
+  context "when accessing a non-published news_item" do
+    let(:draft_news_item) { create :news_item, state: "draft" }
+    let(:archived_news_item) { create :news_item, state: "draft" }
 
-    it 'raises a RecordNotFound error' do
+    it "raises a RecordNotFound error" do
       [draft_news_item, archived_news_item].each do |news_item|
-        expect{
+        expect do
           get :show, id: news_item
-        }.to raise_error ActiveRecord::RecordNotFound
+        end.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
-
 end

--- a/spec/factories/news_items.rb
+++ b/spec/factories/news_items.rb
@@ -1,8 +1,6 @@
 FactoryGirl.define do
-
   factory :news_item do
-    title  'my-title'
-    published_at Time.now
+    title "my-title"
+    published_at Time.now.utc
   end
-
 end

--- a/spec/factories/news_items.rb
+++ b/spec/factories/news_items.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
+
   factory :news_item do
-    
+    title  'my-title'
+    published_at Time.now
   end
 
 end


### PR DESCRIPTION
New stuff:

* Add markdown support for those models: `Event`, `NewsItem`, `Organization`, `Page`.

Note 1: when the 'show' route was missing, in an attempt to minimize confusion between features (different people working simultaneously on different features), I created the 'show' template _only_ when the corresponding (non-admin) controller was present in the codebase. Hence, I left out the `Talk` and `Job` models.

Note 2: the `filter` attribute has been ignored, as was requested by @benichu .

Code reviews are welcome of course, even tough it's pretty basic at this point.