### PR TITLE
Creating an event with default values explodes in the admin interface

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -15,6 +15,7 @@ class Event < ActiveRecord::Base
   # suggestion from Nicholas
   to_param :title
 
+  validates :title, presence: true
   validates :starts_at, presence: true
 
   def self.published

--- a/db/migrate/20140929233719_create_events.rb
+++ b/db/migrate/20140929233719_create_events.rb
@@ -5,7 +5,7 @@ class CreateEvents < ActiveRecord::Migration
       t.datetime :starts_at, null: false
       t.timestamps
     end
-    Event.create_translation_table! :title => :string, :introduction => :text, :conclusion => :text
+    Event.create_translation_table! title: :string, introduction: :text, conclusion: :text
   end
 
   def down

--- a/db/migrate/20151204172708_make_events_title_required.rb
+++ b/db/migrate/20151204172708_make_events_title_required.rb
@@ -1,0 +1,5 @@
+class MakeEventsTitleRequired < ActiveRecord::Migration
+  def change
+    change_column :event_translations, :title, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151125023733) do
+ActiveRecord::Schema.define(version: 20151204172708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20151125023733) do
     t.string   "locale",       null: false
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
-    t.string   "title"
+    t.string   "title",        null: false
     t.text     "introduction"
     t.text     "conclusion"
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -9,16 +9,21 @@
 #  updated_at :datetime
 #
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Event, :type => :model do
 
-  describe 'attribute validations' do
-    it 'does not validate when starts_at is not defined' do
+  describe "attribute validations" do
+    it "does not validate when 'starts_at' is not defined" do
       event = Event.new(starts_at: nil)
-      expect(event).to_not be_valid
+      expect(event).to be_invalid
       expect(event.errors.messages.keys).to include :starts_at
     end
-  end
 
+    it "does not validate when 'title' is not defined" do
+      event = Event.new(title: nil)
+      expect(event).to be_invalid
+      expect(event.errors.messages.keys).to include :title
+    end
+  end
 end


### PR DESCRIPTION
This PR is a pretext to close issue #94 (which already has its fix in the `master` branch). In addition to that, I took the opportunity to make `Event#title` a required field.

Note that I modified the original "events" migration directly, as I don't think we have proper data in the database just yet. If this is causing any kind of problem, I'm happy to revert those changes and create a brand new migration expressly for that.