### PR TITLE
Fixed Issue #117 Add Validation to News Items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development, :test do
   gem "guard-rubocop"
   gem "pry"
   gem "rspec-rails"
+  gem 'shoulda-matchers'
   gem "rubocop", require: false
   gem "sqlite3"
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,6 +315,8 @@ GEM
       tilt (>= 1.1, < 3)
     selectize-rails (0.12.1)
     shellany (0.0.1)
+    shoulda-matchers (3.0.1)
+      activesupport (>= 4.0.0)
     simple_form (3.2.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -400,6 +402,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails
+  shoulda-matchers
   simple_form
   spring
   spring-commands-rspec

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -17,14 +17,22 @@ class NewsItem < ActiveRecord::Base
   scope :published, -> { where(state: :published).order(published_at: :desc) }
 
   # Validations
-  validates :published_at, presence: true, if: -> { state.try(:published?) }
-  validates :title, presence: true, length: {maximum: 255}
-  validates :state, presence: true, inclusion: { in: AVAILABLE_STATES }
-  validates :body, presence: true, length: {maximum: 4000}
+  validates :published_at,
+            presence: true,
+            if: -> { state.try(:published?) }
+  validates :title,
+            presence: true,
+            length: { maximum: MAX_STRING_COLUMN_LENGTH }
+  validates :body,
+            presence: true,
+            length: { maximum: MAX_TEXT_COLUMN_LENGTH }
+  validates :state,
+            presence: true,
+            inclusion: { in: STATES }
 
   # Class methods
-  AVAILABLE_STATES = %w(draft archived published)
-  enumerize :state, in: AVAILABLE_STATES
+  STATES = %w(draft published archived)
+  enumerize :state, in: STATES
   to_param :title
 
   # Instance methods

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -17,11 +17,14 @@ class NewsItem < ActiveRecord::Base
   scope :published, -> { where(state: :published).order(published_at: :desc) }
 
   # Validations
-  validates :published_at, presence: true, if: -> { state.published? }
-  validates_presence_of :title, :state
+  validates :published_at, presence: true, if: -> { state.try(:published?) }
+  validates :title, presence: true, length: {maximum: 255}
+  validates :state, presence: true, inclusion: {in: AVAILABLE_STATES, message: "must be one of the following: #{AVAILABLE_STATES.join(', ')}"}
+  validates :body, presence: true, length: {maximum: 4000}
 
   # Class methods
-  enumerize :state, in: [:draft, :archived, :published]
+  AVAILABLE_STATES = %w(draft archived published)
+  enumerize :state, in: AVAILABLE_STATES
   to_param :title
 
   # Instance methods

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -13,6 +13,9 @@ class NewsItem < ActiveRecord::Base
   # Extends
   extend Enumerize
 
+  # Constants
+  STATES = %w(draft published archived)
+
   # Scopes
   scope :published, -> { where(state: :published).order(published_at: :desc) }
 
@@ -31,7 +34,6 @@ class NewsItem < ActiveRecord::Base
             inclusion: { in: STATES }
 
   # Class methods
-  STATES = %w(draft published archived)
   enumerize :state, in: STATES
   to_param :title
 

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -19,7 +19,7 @@ class NewsItem < ActiveRecord::Base
   # Validations
   validates :published_at, presence: true, if: -> { state.try(:published?) }
   validates :title, presence: true, length: {maximum: 255}
-  validates :state, presence: true, inclusion: {in: AVAILABLE_STATES, message: "must be one of the following: #{AVAILABLE_STATES.join(', ')}"}
+  validates :state, presence: true, inclusion: { in: AVAILABLE_STATES }
   validates :body, presence: true, length: {maximum: 4000}
 
   # Class methods

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -1,0 +1,6 @@
+module ActiveRecordExtensions
+  MAX_STRING_COLUMN_LENGTH = 255
+  MAX_TEXT_COLUMN_LENGTH = 65_536
+end
+
+ActiveRecord::Base.send(:include, ActiveRecordExtensions)

--- a/spec/factories/news_items.rb
+++ b/spec/factories/news_items.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
 
     factory :draft_news_item do
       state :draft
-      body nil
+      body { Faker::Lorem.paragraph }
       published_at nil
     end
 

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -22,57 +22,59 @@ RSpec.describe NewsItem, type: :model do
     end
   end
 
-  describe 'validation' do
-    it {should validate_presence_of(:title)}
-    it {should validate_length_of(:title).is_at_most(255)}
-    it {should validate_presence_of(:body)}
-    it {should validate_length_of(:body).is_at_most(4000)}
-    context 'for state' do
+  describe "validation" do
+    it { should validate_presence_of(:title) }
+    it { should validate_length_of(:title).is_at_most(255) }
+    it { should validate_presence_of(:body) }
+    it { should validate_length_of(:body).is_at_most(4000) }
+    context "for state" do
       NewsItem::AVAILABLE_STATES.each do |state|
         it "passes for value #{state}" do
-          news_item = NewsItem.new(title: 'title', body: 'body', state: state, published_at: Date.yesterday)
+          news_item = build(:news_item, state: state)
           expect(news_item).to be_valid
         end
       end
       it "fails for invalid value" do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: "someinvalidvalue", published_at: Date.yesterday)
+        news_item = build(:news_item, state: "someinvalidvalue")
         expect(news_item).to_not be_valid
         expect(news_item.errors.messages[:state]).to be_present
       end
       it "fails for empty value" do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: "", published_at: Date.yesterday)
+        news_item = build(:news_item, state: "")
         expect(news_item).to_not be_valid
         expect(news_item.errors.messages[:state]).to be_present
       end
       it "fails for not being present (nil value)" do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: nil, published_at: Date.yesterday)
+        news_item = build(:news_item, state: nil)
         expect(news_item).to_not be_valid
         expect(news_item.errors.messages[:state]).to be_present
       end
     end
-    context 'for published_at' do
-      it 'passes when published_at is present and the news item state is published' do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: :published, published_at: Date.yesterday)
+    context "for published_at" do
+      it "passes when published_at is present and the news item state is
+          published" do
+        news_item = build :news_item,
+                          state: :published,
+                          published_at: Date.yesterday
         expect(news_item).to be_valid
         expect(news_item.errors.messages[:published_at]).to_not be_present
       end
-      it 'fails when published_at is not present and the news item state is published' do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: 'published', published_at: nil)
+      it "fails when published_at is not present and the news item state is
+          published" do
+        news_item = build(:news_item, state: "published", published_at: nil)
         expect(news_item).to_not be_valid
         expect(news_item.errors.messages[:published_at]).to be_present
       end
-      it 'passes when published_at is not present and the news item state is other than published' do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: 'draft', published_at: nil)
-        expect(news_item).to be_valid #state is nil
+      it "passes when published_at is not present and the news item state is
+          other than published" do
+        news_item = build(:news_item, state: "draft", published_at: nil)
+        expect(news_item).to be_valid
         expect(news_item.errors.messages[:published_at]).to_not be_present
       end
-      # this one was a bug discovered (but not reported) on Dec 4, 2015 relating to state
-      # value of nil crashing the published_at validation when submitting a new news item
-      # with nothing filled in, despite having a state presence validation since both
-      # validations run anyways.
-      it 'passes when published_at is not present and the news item state is nil' do
-        news_item = NewsItem.new(title: 'title', body: 'body', state: nil, published_at: nil)
-        expect(news_item).to_not be_valid #state is nil
+      it "passes when published_at is not present and the news item state is
+          nil" do
+        news_item = build(:news_item, state: nil, published_at: nil)
+        expect(news_item).to_not be_valid # state is nil
         expect(news_item.errors.messages[:published_at]).to_not be_present
       end
     end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -24,11 +24,17 @@ RSpec.describe NewsItem, type: :model do
 
   describe "validation" do
     it { should validate_presence_of(:title) }
-    it { should validate_length_of(:title).is_at_most(255) }
+    it do
+      should validate_length_of(:title).
+        is_at_most(ActiveRecordExtensions::MAX_STRING_COLUMN_LENGTH)
+    end
     it { should validate_presence_of(:body) }
-    it { should validate_length_of(:body).is_at_most(4000) }
+    it do
+      should validate_length_of(:body).
+        is_at_most(ActiveRecordExtensions::MAX_TEXT_COLUMN_LENGTH)
+    end
     context "for state" do
-      NewsItem::AVAILABLE_STATES.each do |state|
+      NewsItem::STATES.each do |state|
         it "passes for value #{state}" do
           news_item = build(:news_item, state: state)
           expect(news_item).to be_valid

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -21,4 +21,60 @@ RSpec.describe NewsItem, type: :model do
       expect(NewsItem.published).not_to include draft_item
     end
   end
+
+  describe 'validation' do
+    it {should validate_presence_of(:title)}
+    it {should validate_length_of(:title).is_at_most(255)}
+    it {should validate_presence_of(:body)}
+    it {should validate_length_of(:body).is_at_most(4000)}
+    context 'for state' do
+      NewsItem::AVAILABLE_STATES.each do |state|
+        it "passes for value #{state}" do
+          news_item = NewsItem.new(title: 'title', body: 'body', state: state, published_at: Date.yesterday)
+          expect(news_item).to be_valid
+        end
+      end
+      it "fails for invalid value" do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: "someinvalidvalue", published_at: Date.yesterday)
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:state]).to be_present
+      end
+      it "fails for empty value" do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: "", published_at: Date.yesterday)
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:state]).to be_present
+      end
+      it "fails for not being present (nil value)" do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: nil, published_at: Date.yesterday)
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:state]).to be_present
+      end
+    end
+    context 'for published_at' do
+      it 'passes when published_at is present and the news item state is published' do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: :published, published_at: Date.yesterday)
+        expect(news_item).to be_valid
+        expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+      it 'fails when published_at is not present and the news item state is published' do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: 'published', published_at: nil)
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:published_at]).to be_present
+      end
+      it 'passes when published_at is not present and the news item state is other than published' do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: 'draft', published_at: nil)
+        expect(news_item).to be_valid #state is nil
+        expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+      # this one was a bug discovered (but not reported) on Dec 4, 2015 relating to state
+      # value of nil crashing the published_at validation when submitting a new news item
+      # with nothing filled in, despite having a state presence validation since both
+      # validations run anyways.
+      it 'passes when published_at is not present and the news item state is nil' do
+        news_item = NewsItem.new(title: 'title', body: 'body', state: nil, published_at: nil)
+        expect(news_item).to_not be_valid #state is nil
+        expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+    end
+  end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe NewsItem, type: :model do
   end
 
   describe "validation" do
-    it { should validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:title) }
     it do
-      should validate_length_of(:title).
+      is_expected.to validate_length_of(:title).
         is_at_most(ActiveRecordExtensions::MAX_STRING_COLUMN_LENGTH)
     end
-    it { should validate_presence_of(:body) }
+    it { is_expected.to validate_presence_of(:body) }
     it do
-      should validate_length_of(:body).
+      is_expected.to validate_length_of(:body).
         is_at_most(ActiveRecordExtensions::MAX_TEXT_COLUMN_LENGTH)
     end
     context "for state" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,3 +78,10 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Fixed https://github.com/montrealrb/Montreal.rb/issues/117
As part of that, I added news item rspec tests and altered display of state field in the admin dashboard for news item to show a dropdown for the state enum. I added shoulda-matchers as part of my work on the tests. I hope you don't mind. I don't like to use them for every validation test, but only for the most simple and mundane boilerplate ones. The rest, I wrote standard rspec tests for.

This is my first contribution, so I'm new and can benefit from criticism and pointing in the right direction given I have not worked with this team before. 

Thanks for the opportunity and cheers.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/montrealrb/montreal.rb/125)
<!-- Reviewable:end -->
