### PR TITLE
Added .ruby-gemset

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+Montreal-rb


### PR DESCRIPTION
Configured rvm gemset to scope project gems independently of other Ruby projects. For example, that makes it possible to configure same gem versions for different projects, but with different native binding configurations or CPU architectures (e.g. x86 vs x64). Also, it makes it easier to delete all project gems from machine when removing project or upgrading to a new version of Ruby, without disturbing other project gems that might be dependent on older version of Ruby (using "rvm gemset empty" command).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/montrealrb/montreal.rb/134)
<!-- Reviewable:end -->
