### PR TITLE
Locations: remove 'translation ids' field in admin interface

### DIFF
--- a/app/dashboards/location_dashboard.rb
+++ b/app/dashboards/location_dashboard.rb
@@ -37,7 +37,6 @@ class LocationDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :translations,
     :name,
     :address,
     :url,


### PR DESCRIPTION
Fix issue #108.