### PR TITLE
[chore] Adds rubocop to run ruby style checking locally and automatically

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from: .ruby-style.yml
+
+# Pending decision @ https://github.com/montrealrb/Montreal.rb/issues/131
+Style/StringLiterals:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 99

--- a/Gemfile
+++ b/Gemfile
@@ -50,14 +50,16 @@ group :development do
 end
 
 group :development, :test do
+  gem 'capybara'
   gem 'factory_girl_rails'
   gem 'faker'
   gem 'guard'
   gem 'guard-ctags-bundler'
   gem 'guard-rspec', require: false
+  gem 'guard-rubocop'
   gem 'pry'
   gem 'rspec-rails'
-  gem 'capybara'
+  gem 'rubocop', require: false
   gem 'sqlite3'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
       activerecord (>= 3.2, <= 4.3)
       rake (~> 10.4)
     arel (6.0.3)
+    ast (2.1.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     autoprefixer-rails (6.1.2)
       execjs
       json
@@ -145,6 +148,9 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.2.0)
+      guard (~> 2.0)
+      rubocop (~> 0.20)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -188,7 +194,10 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
     pg (0.18.4)
+    powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -225,6 +234,7 @@ GEM
       activesupport (= 4.2.5)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     raindrops (0.15.0)
     rake (10.4.2)
     rb-fsevent (0.9.6)
@@ -258,6 +268,14 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.0)
+    rubocop (0.35.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.3.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      tins (<= 1.6.0)
+    ruby-progressbar (1.7.5)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -335,6 +353,7 @@ DEPENDENCIES
   guard
   guard-ctags-bundler
   guard-rspec
+  guard-rubocop
   jquery-rails
   newrelic_rpm
   pg
@@ -343,6 +362,7 @@ DEPENDENCIES
   rails_12factor
   redcarpet
   rspec-rails
+  rubocop
   sass-rails
   simple_form
   spring

--- a/Guardfile
+++ b/Guardfile
@@ -24,3 +24,8 @@ guard 'ctags-bundler', :src_path => ["app", "lib"] do
   watch(/^(app|lib|spec\/support)\/.*\.rb$/)
   watch('Gemfile.lock')
 end
+
+guard :rubocop, cli: ['--rails'] do
+  watch(%r{.+\.rb$})
+  watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ Coveralls.wear!
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 
-
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Running automatically on file changes when you use `guard` in your development
process

cc @cawel