### PR TITLE
Fix #115 - add 'user_id' to 3 models: Event, Job, NewsItem

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,19 +1,5 @@
 module Admin
   class EventsController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # simply overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Event.all.paginate(10, params[:page])
-    # end
-
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Event.find_by!(slug: param)
-    # end
-
-    # See https://administrate-docs.herokuapp.com/customizing_controller_actions
-    # for more information
+    include AdministrateCustomization
   end
 end

--- a/app/controllers/admin/jobs_controller.rb
+++ b/app/controllers/admin/jobs_controller.rb
@@ -1,4 +1,5 @@
 module Admin
   class JobsController < Admin::ApplicationController
+    include AdministrateCustomization
   end
 end

--- a/app/controllers/admin/news_items_controller.rb
+++ b/app/controllers/admin/news_items_controller.rb
@@ -1,19 +1,5 @@
 module Admin
   class NewsItemsController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # simply overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = NewsItem.all.paginate(10, params[:page])
-    # end
-
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   NewsItem.find_by!(slug: param)
-    # end
-
-    # See https://administrate-docs.herokuapp.com/customizing_controller_actions
-    # for more information
+    include AdministrateCustomization
   end
 end

--- a/app/controllers/concerns/admin/administrate_customization.rb
+++ b/app/controllers/concerns/admin/administrate_customization.rb
@@ -1,0 +1,11 @@
+module Admin
+  module AdministrateCustomization
+    extend ActiveSupport::Concern
+
+    private
+
+    def resource_params
+      super.merge(user_id: current_user.id)
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,12 +12,14 @@
 class Event < ActiveRecord::Base
   translates :title, :introduction, :conclusion
   belongs_to :location
-  # suggestion from Nicholas
+  belongs_to :author, foreign_key: :user_id, class_name: "User"
+
   to_param :title
 
   validates :title, presence: true
   validates :starts_at, presence: true
   validates :location, presence: true
+  validates :author, presence: true
 
   def self.published
     order(starts_at: :desc)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -3,6 +3,7 @@ class Job < ActiveRecord::Base
   STATES = %w(draft published archived).freeze
 
   belongs_to :organization
+  belongs_to :author, foreign_key: :user_id, class_name: "User"
 
   scope :published, -> { where(state: :published).order(created_at: :desc) }
 
@@ -17,4 +18,5 @@ class Job < ActiveRecord::Base
   validates :state,
             presence: true,
             inclusion: { in: STATES }
+  validates :author, presence: true
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -10,6 +10,8 @@
 #   can still resolve: http://www.montrealrb.com/[post_date:YYYY]/[post_date:MM]/[post_name]
 #
 class NewsItem < ActiveRecord::Base
+  belongs_to :author, foreign_key: :user_id, class_name: "User"
+
   # Extends
   extend Enumerize
 
@@ -32,6 +34,7 @@ class NewsItem < ActiveRecord::Base
   validates :state,
             presence: true,
             inclusion: { in: STATES }
+  validates :author, presence: true
 
   # Class methods
   enumerize :state, in: STATES, default: :draft

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@
 #  updated_at             :datetime
 #
 class User < ActiveRecord::Base
+  DEFAULT_USER_EMAIL = "default.user@montrealrb.com".freeze
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -37,5 +39,18 @@ class User < ActiveRecord::Base
         user.email = data["email"] if user.email.blank?
       end
     end
+  end
+
+  def self.create_default_user!
+    User.create! email: User::DEFAULT_USER_EMAIL, password: "12345678"
+  end
+
+  def self.default_user
+    User.find_by(email: DEFAULT_USER_EMAIL)
+  end
+
+  # make it impossible for the default user to authenticate
+  def active_for_authentication?
+    super && email != DEFAULT_USER_EMAIL
   end
 end

--- a/db/migrate/20151209201426_add_user_id_to_some_models.rb
+++ b/db/migrate/20151209201426_add_user_id_to_some_models.rb
@@ -1,0 +1,25 @@
+class AddUserIdToSomeModels < ActiveRecord::Migration
+  def up
+    add_column :events, :user_id, :integer, null: false
+    add_column :jobs, :user_id, :integer, null: false
+    add_column :news_items, :user_id, :integer
+
+    User.create_default_user! if User.default_user.blank?
+    NewsItem.update_all user_id: User.default_user.id
+    change_column_null :news_items, :user_id, false
+
+    add_index :events, :user_id
+    add_index :jobs, :user_id
+    add_index :news_items, :user_id
+  end
+
+  def down
+    remove_index :events, :user_id
+    remove_index :jobs, :user_id
+    remove_index :news_items, :user_id
+
+    remove_column :events, :user_id
+    remove_column :jobs, :user_id
+    remove_column :news_items, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,10 +34,12 @@ ActiveRecord::Schema.define(version: 20151213185304) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "location_id", null: false
+    t.integer  "user_id",     null: false
   end
 
   add_index "events", ["location_id"], name: "index_events_on_location_id", using: :btree
   add_index "events", ["starts_at"], name: "index_events_on_starts_at", using: :btree
+  add_index "events", ["user_id"], name: "index_events_on_user_id", using: :btree
 
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string   "slug",                      null: false
@@ -59,8 +61,10 @@ ActiveRecord::Schema.define(version: 20151213185304) do
     t.integer  "organization_id"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.integer  "user_id",         null: false
   end
 
+  add_index "jobs", ["user_id"], name: "index_jobs_on_user_id", using: :btree
 
   create_table "location_translations", force: :cascade do |t|
     t.integer  "location_id", null: false
@@ -90,9 +94,11 @@ ActiveRecord::Schema.define(version: 20151213185304) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.string   "slug"
+    t.integer  "user_id",      null: false
   end
 
   add_index "news_items", ["slug"], name: "index_news_items_on_slug", using: :btree
+  add_index "news_items", ["user_id"], name: "index_news_items_on_user_id", using: :btree
 
   create_table "organization_translations", force: :cascade do |t|
     t.integer  "organization_id", null: false

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Admin::EventsController, type: :controller do
+  let(:admin) { FactoryGirl.create(:user, :admin) }
+  let(:valid_attributes) do
+    attributes_for(:event).merge(author: nil,
+                                 location_id: create(:location).id)
+  end
+
+  describe "POST #create" do
+    before do
+      login_user(admin)
+    end
+
+    it "creates a new event" do
+      expect do
+        post :create, event: valid_attributes
+      end.to change(Event, :count).by(1)
+    end
+
+    it "assigns the current user to the 'author' field" do
+      post :create, event: valid_attributes
+      expect(Event.last.author).to eq admin
+    end
+  end
+
+  describe "PUT #update" do
+    let(:event) { create :event }
+    before do
+      login_user(admin)
+    end
+
+    it "assigns the current user to the 'author' field" do
+      put :update, id: event.id, event: event.attributes
+      expect(event.reload.author).to eq admin
+    end
+  end
+end

--- a/spec/controllers/admin/jobs_controller_spec.rb
+++ b/spec/controllers/admin/jobs_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Admin::JobsController, type: :controller do
+  let(:admin) { FactoryGirl.create(:user, :admin) }
+  let(:valid_attributes) { attributes_for(:job).merge(author: nil) }
+
+  describe "POST #create" do
+    before do
+      login_user(admin)
+    end
+
+    it "creates a new job" do
+      expect do
+        post :create, job: valid_attributes
+      end.to change(Job, :count).by(1)
+    end
+
+    it "assigns the current user to the 'author' field" do
+      post :create, job: valid_attributes
+      expect(Job.last.author).to eq admin
+    end
+  end
+
+  describe "PUT #update" do
+    let(:job) { create :job }
+    before do
+      login_user(admin)
+    end
+
+    it "assigns the current user to the 'author' field" do
+      put :update, id: job.id, job: job.attributes
+      expect(job.reload.author).to eq admin
+    end
+  end
+end

--- a/spec/controllers/admin/news_items_controller_spec.rb
+++ b/spec/controllers/admin/news_items_controller_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Admin::NewsItemsController, type: :controller do
+  let(:admin) { FactoryGirl.create(:user, :admin) }
+  let(:valid_attributes) do
+    attributes_for(:news_item).merge(author: nil)
+  end
+
+  describe "POST #create" do
+    before do
+      login_user(admin)
+    end
+
+    it "creates a new news_item" do
+      expect do
+        post :create, news_item: valid_attributes
+      end.to change(NewsItem, :count).by(1)
+    end
+
+    it "assigns the current user to the 'author' field" do
+      post :create, news_item: valid_attributes
+      expect(NewsItem.last.author).to eq admin
+    end
+  end
+
+  describe "PUT #update" do
+    let(:news_item) { create :news_item }
+    before do
+      login_user(admin)
+    end
+
+    it "assigns the current user to the 'author' field" do
+      put :update, id: news_item.id, news_item: news_item.attributes
+      expect(news_item.reload.author).to eq admin
+    end
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :event do
     association :location
+    association :author, factory: :user
 
     starts_at { Faker::Date.between(30.days.ago, 30.days.from_now) }
 

--- a/spec/factories/jobs.rb
+++ b/spec/factories/jobs.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :job do
     association :organization
+    association :author, factory: :user
 
     state { Job::STATES.sample }
     title { Faker::Lorem.sentence }

--- a/spec/factories/news_items.rb
+++ b/spec/factories/news_items.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   # Default factory is a NewsItem that has just been published
   factory :news_item do
+    association :author, factory: :user
+
     state { Job::STATES.sample }
     title { Faker::Lorem.sentence }
     body { Faker::Lorem.paragraph }

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe Organization, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -30,5 +30,19 @@ RSpec.describe Event, type: :model do
       expect(event).to be_invalid
       expect(event.errors.messages.keys).to include :title
     end
+
+    it "does not validate when 'author' is not defined" do
+      event = Event.new(author: nil)
+      expect(event).to be_invalid
+      expect(event.errors.messages.keys).to include :author
+    end
+  end
+
+  context "when an event is authored" do
+    it "knows about its author" do
+      author = create(:user)
+      event = create(:event, author: author)
+      expect(event.author).to eq author
+    end
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Job, type: :model do
       is_expected.to validate_length_of(:description).
         is_at_most(ActiveRecordExtensions::MAX_TEXT_COLUMN_LENGTH)
     end
+
     context "for state" do
       Job::STATES.each do |state|
         it "passes for value #{state}" do
@@ -34,6 +35,22 @@ RSpec.describe Job, type: :model do
         expect(job).to_not be_valid
         expect(job.errors.messages[:state]).to be_present
       end
+    end
+
+    context "for author" do
+      it "does not validate when 'author' is not defined" do
+        job = Job.new(author: nil)
+        expect(job).to be_invalid
+        expect(job.errors.messages.keys).to include :author
+      end
+    end
+  end
+
+  describe "when a job is authored" do
+    it "knows about its author" do
+      author = create(:user)
+      job = create(:job, author: author)
+      expect(job.author).to eq author
     end
   end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe NewsItem, type: :model do
       is_expected.to validate_length_of(:body).
         is_at_most(ActiveRecordExtensions::MAX_TEXT_COLUMN_LENGTH)
     end
+
     context "for state" do
       NewsItem::STATES.each do |state|
         it "passes for value #{state}" do
@@ -56,6 +57,7 @@ RSpec.describe NewsItem, type: :model do
         expect(news_item.errors.messages[:state]).to be_present
       end
     end
+
     context "for published_at" do
       it "passes when published_at is present and the news item state is
           published" do
@@ -82,6 +84,22 @@ RSpec.describe NewsItem, type: :model do
         news_item = build(:news_item, state: nil, published_at: nil)
         expect(news_item).to_not be_valid # state is nil
         expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+
+      context "for author" do
+        it "does not validate when 'authored' is not defined" do
+          news_item = NewsItem.new(author: nil)
+          expect(news_item).to be_invalid
+          expect(news_item.errors.messages.keys).to include :author
+        end
+      end
+    end
+
+    context "when a news_item is authored" do
+      it "knows about its author" do
+        author = create(:user)
+        news_item = create(:news_item, author: author)
+        expect(news_item.author).to eq author
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,8 @@ require "spec_helper"
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
+require "devise"
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -44,4 +46,7 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  config.include Devise::TestHelpers, type: :controller
+  config.include ControllerMacros, type: :controller
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -1,0 +1,6 @@
+module ControllerMacros
+  def login_user(user = FactoryGirl.create(:user))
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+    sign_in user
+  end
+end


### PR DESCRIPTION
- Add an `author` relationship to all of those 3 models
- Make the `user_id` field mandatory in both db and model
- Assign the `user_id` field to the current user when creating/updating any of those 3 models in the admin interface
- Empower `Faker` in a few factories
- Add model specs
- Add admin controller specs involving `Devise`
- Add a rake task to create a default user in the database
- Require the existence of the default user in db for the rake task importing the legacy db data
- Add methods related to the default user in the `User` model
- Remove useless `news_item_helper` and its spec
- Remove useless `home_helper`
- Fix old style rails code in model

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/montrealrb/montreal.rb/150)
<!-- Reviewable:end -->
