### PR TITLE
Guard: move the rails cops config to rubocop's config file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,11 @@
 inherit_from: .ruby-style.yml
 
+AllCops:
+  RunRailsCops: true
+  Exclude:
+    - 'db/schema.rb'
+    - 'bin/**/*'
+
 # Pending decision @ https://github.com/montrealrb/Montreal.rb/issues/131
 Style/StringLiterals:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ group :development, :test do
   gem 'capybara'
   gem 'factory_girl_rails'
   gem 'faker'
-  gem 'guard'
   gem 'guard-ctags-bundler'
   gem 'guard-rspec', require: false
   gem 'guard-rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,6 @@ DEPENDENCIES
   font-awesome-sass
   globalize
   globalize-accessors
-  guard
   guard-ctags-bundler
   guard-rspec
   guard-rubocop

--- a/Guardfile
+++ b/Guardfile
@@ -25,7 +25,7 @@ guard 'ctags-bundler', :src_path => ["app", "lib"] do
   watch('Gemfile.lock')
 end
 
-guard :rubocop, cli: ['--rails'] do
+guard :rubocop do
   watch(%r{.+\.rb$})
   watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
 end


### PR DESCRIPTION
- Include all the rails cops in rubocop's config file
- Remove the 'guard' gem as it is already a dependency of other gems

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/montrealrb/montreal.rb/157)
<!-- Reviewable:end -->
