### PR TITLE
Pages: empower the 'friendly_id' gem to generate slugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 ruby "2.2.4"
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", "~> 4.2.2"
 
 # Database
 gem "pg"
@@ -12,16 +10,20 @@ gem "carrierwave"
 gem "cloudinary"
 
 # Assets
-gem "devise", "~> 3.5.2"
-gem "omniauth-github"
-gem "autoprefixer-rails", "~> 6.1.0"
-gem "bootstrap-sass", "~> 3.3.6"
-gem "font-awesome-sass"
-gem "coffee-rails", "~> 4.1.0"
-gem "jquery-rails"
-gem "sass-rails"
-gem "uglifier", ">= 1.3.0"
-gem "sprockets", "~> 3.0"
+gem 'autoprefixer-rails', '~> 6.1.0'
+gem 'bootstrap-sass', '~> 3.3.6'
+gem 'font-awesome-sass'
+gem 'coffee-rails', '~> 4.1.0'
+gem 'jquery-rails'
+gem 'sass-rails'
+gem 'uglifier', '>= 1.3.0'
+gem 'sprockets', '~> 3.0'
+
+# Application
+gem 'rails', '~> 4.2.2'
+gem 'omniauth-github'
+gem 'friendly_id', '~> 5.1.0'
+gem 'devise', '~> 3.5.2'
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     font-awesome-sass (4.5.0)
       sass (>= 3.2)
     formatador (0.2.5)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     globalize (5.0.1)
@@ -376,6 +378,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   font-awesome-sass
+  friendly_id (~> 5.1.0)
   globalize
   globalize-accessors
   guard-ctags-bundler

--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -9,9 +9,9 @@ module Admin
     # end
 
     # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Page.find_by!(slug: param)
-    # end
+    def find_resource(param)
+      Page.friendly.find(param)
+    end
 
     # See https://administrate-docs.herokuapp.com/customizing_controller_actions
     # for more information

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   def show
-    @page = Page.published.find(params[:id])
+    @page = Page.friendly.published.find(params[:id])
   end
 
   def about; end

--- a/app/dashboards/page_dashboard.rb
+++ b/app/dashboards/page_dashboard.rb
@@ -12,6 +12,7 @@ class PageDashboard < Administrate::BaseDashboard
     title: Field::String,
     body: Field::Text,
     state: EnumField,
+    slug: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -25,7 +26,8 @@ class PageDashboard < Administrate::BaseDashboard
     :id,
     :title,
     :body,
-    :state
+    :state,
+    :slug
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,10 +1,12 @@
 class Page < ActiveRecord::Base
   extend Enumerize
+  extend FriendlyId
 
   translates :title, :body
+  friendly_id :title, use: [:slugged, :history]
 
   # Static Class Variables
-  STATES = %w(draft published archived).freeze
+  STATES = %i(draft published archived).freeze
 
   validates :title, presence: true
   validates :state, presence: true
@@ -13,4 +15,10 @@ class Page < ActiveRecord::Base
   enumerize :state, in: STATES, default: :draft
 
   scope :published, -> { where(state: "published") }
+
+  private
+
+  def should_generate_new_friendly_id?
+    slug.blank? || changed.include?("title")
+  end
 end

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+                             stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20151213183525_create_friendly_id_slugs.rb
+++ b/db/migrate/20151213183525_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string :slug, null: false
+      t.integer :sluggable_id, null: false
+      t.string :sluggable_type, limit: 50
+      t.string :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/migrate/20151213185304_add_slug_to_page.rb
+++ b/db/migrate/20151213185304_add_slug_to_page.rb
@@ -1,0 +1,12 @@
+class AddSlugToPage < ActiveRecord::Migration
+  def change
+    add_column :pages, :slug, :string, null: false, default: 'temporary-slug'
+
+    # make sure we define a slug for existing pages
+    Page.find_each do |page|
+      page.update(slug: '')
+    end
+
+    add_index :pages, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151204174632) do
+ActiveRecord::Schema.define(version: 20151213185304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,19 @@ ActiveRecord::Schema.define(version: 20151204174632) do
   add_index "events", ["location_id"], name: "index_events_on_location_id", using: :btree
   add_index "events", ["starts_at"], name: "index_events_on_starts_at", using: :btree
 
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+  end
+
+  add_index "friendly_id_slugs", ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+  add_index "friendly_id_slugs", ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+  add_index "friendly_id_slugs", ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
+
   create_table "jobs", force: :cascade do |t|
     t.string   "state"
     t.string   "title"
@@ -47,6 +60,7 @@ ActiveRecord::Schema.define(version: 20151204174632) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
   end
+
 
   create_table "location_translations", force: :cascade do |t|
     t.integer  "location_id", null: false
@@ -112,9 +126,10 @@ ActiveRecord::Schema.define(version: 20151204174632) do
   add_index "page_translations", ["page_id"], name: "index_page_translations_on_page_id", using: :btree
 
   create_table "pages", force: :cascade do |t|
-    t.string   "state",      null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "state",                                 null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.string   "slug",       default: "temporary-slug", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
- Slug history is enabled (by creating a new db table)
- Slug is updated if the `title` attribute changes
- Show `slug` field on the index page
- Show `slug` field on the show page
- Fix #35