### PR TITLE
Ignore .powrc and .ruby-gemset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@
 # Ignore Image uploads
 /public/uploads/
 
+# Ignore pow.cx configuration
+.powrc
+
+# Ignore RVM ruby gemset
+.ruby-gemset
+
 config/database.yml
 
 # ctags


### PR DESCRIPTION
This compensates for my previously closed pull requests about .powrc and .ruby-gemset