### PR TITLE
Fix mistake in event factory

### DIFF
--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :event do
     association :location
 
-    starts_at { Faker::Date.between(30.days.ago, 30.days) }
+    starts_at { Faker::Date.between(30.days.ago, 30.days.from_now) }
 
     # Translatable:
     title { Faker::Lorem.sentence }


### PR DESCRIPTION
The faker `between` methods can't handle `ActiveSupport::Duration`
objects. It's expecting something that can responds to `:to_date`. So
needed to append `.from_now` to adhere to this.