### PR TITLE
[issue/117] Add validations to NewsItem

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -17,8 +17,18 @@ class NewsItem < ActiveRecord::Base
   scope :published, -> { where(state: :published).order(published_at: :desc) }
 
   # Validations
-  validates :published_at, presence: true, if: -> { state.published? }
-  validates_presence_of :title, :state
+  validates :published_at,
+            presence: true,
+            if: -> { state.try(:published?) }
+  validates :title,
+            presence: true,
+            length: { maximum: MAX_STRING_COLUMN_LENGTH }
+  validates :body,
+            presence: true,
+            length: { maximum: MAX_TEXT_COLUMN_LENGTH }
+  validates :state,
+            presence: true,
+            inclusion: { in: STATES }
 
   # Class methods
   enumerize :state, in: [:draft, :archived, :published]

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -21,4 +21,68 @@ RSpec.describe NewsItem, type: :model do
       expect(NewsItem.published).not_to include draft_item
     end
   end
+
+  describe "validation" do
+    it { is_expected.to validate_presence_of(:title) }
+    it do
+      is_expected.to validate_length_of(:title).
+        is_at_most(ActiveRecordExtensions::MAX_STRING_COLUMN_LENGTH)
+    end
+    it { is_expected.to validate_presence_of(:body) }
+    it do
+      is_expected.to validate_length_of(:body).
+        is_at_most(ActiveRecordExtensions::MAX_TEXT_COLUMN_LENGTH)
+    end
+    context "for state" do
+      NewsItem::STATES.each do |state|
+        it "passes for value #{state}" do
+          news_item = build(:news_item, state: state)
+          expect(news_item).to be_valid
+        end
+      end
+      it "fails for invalid value" do
+        news_item = build(:news_item, state: "someinvalidvalue")
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:state]).to be_present
+      end
+      it "fails for empty value" do
+        news_item = build(:news_item, state: "")
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:state]).to be_present
+      end
+      it "fails for not being present (nil value)" do
+        news_item = build(:news_item, state: nil)
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:state]).to be_present
+      end
+    end
+    context "for published_at" do
+      it "passes when published_at is present and the news item state is
+          published" do
+        news_item = build :news_item,
+                          state: :published,
+                          published_at: Date.yesterday
+        expect(news_item).to be_valid
+        expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+      it "fails when published_at is not present and the news item state is
+          published" do
+        news_item = build(:news_item, state: "published", published_at: nil)
+        expect(news_item).to_not be_valid
+        expect(news_item.errors.messages[:published_at]).to be_present
+      end
+      it "passes when published_at is not present and the news item state is
+          other than published" do
+        news_item = build(:news_item, state: "draft", published_at: nil)
+        expect(news_item).to be_valid
+        expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+      it "passes when published_at is not present and the news item state is
+          nil" do
+        news_item = build(:news_item, state: nil, published_at: nil)
+        expect(news_item).to_not be_valid # state is nil
+        expect(news_item.errors.messages[:published_at]).to_not be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rebase, squashed and split out patches from https://github.com/montrealrb/Montreal.rb/pull/125.