### PR TITLE
Auto-email Montreal.rb slack invite to new users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,20 @@ class ApplicationController < ActionController::Base
   before_action :load_sidebar
 
   def after_sign_in_path_for(_resource)
+    slack_check
     return admin_root_path if current_user.admin?
     root_path
   end
 
   def load_sidebar
     @news_items = NewsItem.published
+  end
+
+  private
+
+  def slack_check
+    if env["warden"].user.sign_in_count == 1
+      email_slack_invite(env["warden"].user.email)
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require "open-uri"
+require "colorize"
+
 module ApplicationHelper
   def full_title(page_title = "")
     base_title = "Montreal.rb"
@@ -6,6 +9,34 @@ module ApplicationHelper
       base_title
     else
       page_title + " | " + base_title
+    end
+  end
+
+  def email_slack_invite(user_email)
+    # Get the channel ID from https://slack.com/api/channels.list?token=<YOUR_TOKEN>
+    channels = ""
+
+    # Get the auth token from: https://api.slack.com/web
+    token = ""
+
+    # Construct the API request URL
+    # This is not documented by Slack, and may not work forever
+    # As it is an unofficial API endpoint, use at your own risk!
+    url = "https://slack.com/api/users.admin.invite"
+    url += "?channels=#{channels}"
+    url += "&set_active=true"
+    url += "&_attempts=1"
+    url += "&token=#{token}"
+    url += "&email=#{URI::escape(user_email)}"
+
+    # Make the request and capture the response
+    response = JSON.parse(open(url).read)
+
+    if response['ok']
+      Rails.logger.info("slack invitation sent to: #{user_email}".colorize(:green))
+    else
+      Rails.logger.info("slack invitation failed to send to #{user_email}".colorize(:red))
+      Rails.logger.info(response.inspect.colorize(:yellow))
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,12 +27,12 @@ module ApplicationHelper
     url += "&set_active=true"
     url += "&_attempts=1"
     url += "&token=#{token}"
-    url += "&email=#{URI::escape(user_email)}"
+    url += "&email=#{URI.escape(user_email)}"
 
     # Make the request and capture the response
     response = JSON.parse(open(url).read)
 
-    if response['ok']
+    if response["ok"]
       Rails.logger.info("slack invitation sent to: #{user_email}".colorize(:green))
     else
       Rails.logger.info("slack invitation failed to send to #{user_email}".colorize(:red))


### PR DESCRIPTION
(work-in-progress, needs admins to try it out since I'm not a slack admin for the team, so can't generate the auth code)

Addresses #242. When a new user signs up, this takes the user's email and sets off a flow to get slack to auto-send them an invite email for the Montreal.rb slack team. The code for the script is inspired by https://ruby.unicorn.tv/screencasts/automatically-send-slack-invitations. Interestingly, it doesn't seem that the slack api has an official endpoint for this, but there are a few scripts that use this unofficial endpoint.

Someone who is an admin for the slack team should try this out in development, specifying the slack channel id to invite the user too, as well as the auth token (which should be and ENV variable and shouldn't be committed to version control). Though it would be great to have a different test auth token so that a test can be written for this as well.
@sophiedeziel @garyharan 