### PR TITLE
[Migrate][Issue 261]Create jobs migration

### DIFF
--- a/db/migrate/20170524022609_add_published_at_to_jobs.rb
+++ b/db/migrate/20170524022609_add_published_at_to_jobs.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToJobs < ActiveRecord::Migration
+  def change
+    add_column :jobs, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170523233820) do
+ActiveRecord::Schema.define(version: 20170524022609) do
 
   create_table "contacts", force: :cascade do |t|
     t.string   "name"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20170523233820) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.integer  "user_id",         null: false
+    t.datetime "published_at"
   end
 
   add_index "jobs", ["user_id"], name: "index_jobs_on_user_id"


### PR DESCRIPTION
One of the request in #261 is to reorder the jobs by the published at date.
However, this field isn't available on the jobs' table.

Sorry for these 3 PRs