### PR TITLE
Add Cloudinary Initializer to force HTTPS

### DIFF
--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,0 +1,3 @@
+Cloudinary.config do |config|
+  config.secure = true
+end


### PR DESCRIPTION
Currently, HTTPS is not full https, at least on main page:
This PR is to force url helper of Cloudinary::CarrierWave module to use HTTPS protocol
![screenshot 2017-10-28 23 46 42](https://user-images.githubusercontent.com/11471420/32140609-a1c213be-bc3d-11e7-96a4-d557869e851b.png)
![screenshot 2017-10-28 23 46 28](https://user-images.githubusercontent.com/11471420/32140610-a1d8cc6c-bc3d-11e7-9d51-b64323a7f867.png)

