### PR TITLE
Add Rails version to ActiveRecord::Migration

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/db/migrate/20140929233719_create_events.rb
+++ b/db/migrate/20140929233719_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[5.1]
   class Event < ActiveRecord::Base
     translates :title, :introduction, :conclusion
   end

--- a/db/migrate/20140929233924_devise_create_users.rb
+++ b/db/migrate/20140929233924_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[5.1]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20140929235828_create_votes.rb
+++ b/db/migrate/20140929235828_create_votes.rb
@@ -1,4 +1,4 @@
-class CreateVotes < ActiveRecord::Migration
+class CreateVotes < ActiveRecord::Migration[5.1]
   def change
     create_table :votes do |t|
       t.references :votable, polymorphic: true, index: true

--- a/db/migrate/20140930000502_create_companies.rb
+++ b/db/migrate/20140930000502_create_companies.rb
@@ -1,4 +1,4 @@
-class CreateCompanies < ActiveRecord::Migration
+class CreateCompanies < ActiveRecord::Migration[5.1]
   class Company < ActiveRecord::Base
     translates :description
   end

--- a/db/migrate/20140930005824_add_bio_to_user.rb
+++ b/db/migrate/20140930005824_add_bio_to_user.rb
@@ -1,4 +1,4 @@
-class AddBioToUser < ActiveRecord::Migration
+class AddBioToUser < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :bio, :string
   end

--- a/db/migrate/20140930010847_index_events_starts_at.rb
+++ b/db/migrate/20140930010847_index_events_starts_at.rb
@@ -1,4 +1,4 @@
-class IndexEventsStartsAt < ActiveRecord::Migration
+class IndexEventsStartsAt < ActiveRecord::Migration[5.1]
   def change
     add_index :events, :starts_at
   end

--- a/db/migrate/20140930011409_create_locations.rb
+++ b/db/migrate/20140930011409_create_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocations < ActiveRecord::Migration
+class CreateLocations < ActiveRecord::Migration[5.1]
   def up
     create_table :locations do |t|
       t.string :name

--- a/db/migrate/20140930012651_location_belongs_to_event.rb
+++ b/db/migrate/20140930012651_location_belongs_to_event.rb
@@ -1,4 +1,4 @@
-class LocationBelongsToEvent < ActiveRecord::Migration
+class LocationBelongsToEvent < ActiveRecord::Migration[5.1]
   def change
     add_reference :events, :location, index: true
   end

--- a/db/migrate/20151124181544_remove_votes.rb
+++ b/db/migrate/20151124181544_remove_votes.rb
@@ -1,4 +1,4 @@
-class RemoveVotes < ActiveRecord::Migration
+class RemoveVotes < ActiveRecord::Migration[5.1]
   def change
     drop_table :votes do |t|
       t.references :votable, polymorphic: true, index: true

--- a/db/migrate/20151124181959_remove_bio_from_users.rb
+++ b/db/migrate/20151124181959_remove_bio_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveBioFromUsers < ActiveRecord::Migration
+class RemoveBioFromUsers < ActiveRecord::Migration[5.1]
   def change
     remove_column :users, :bio, :string
   end

--- a/db/migrate/20151124183742_rename_companies_to_organizations.rb
+++ b/db/migrate/20151124183742_rename_companies_to_organizations.rb
@@ -1,4 +1,4 @@
-class RenameCompaniesToOrganizations < ActiveRecord::Migration
+class RenameCompaniesToOrganizations < ActiveRecord::Migration[5.1]
   def change
    rename_table :companies, :organizations
   end

--- a/db/migrate/20151125004633_create_pages.rb
+++ b/db/migrate/20151125004633_create_pages.rb
@@ -1,4 +1,4 @@
-class CreatePages < ActiveRecord::Migration
+class CreatePages < ActiveRecord::Migration[5.1]
   def up
     create_table :pages do |t|
       t.string :state, null: false

--- a/db/migrate/20151125005902_create_jobs.rb
+++ b/db/migrate/20151125005902_create_jobs.rb
@@ -1,4 +1,4 @@
-class CreateJobs < ActiveRecord::Migration
+class CreateJobs < ActiveRecord::Migration[5.1]
   def change
     create_table :jobs do |t|
       t.string :state

--- a/db/migrate/20151125010131_delete_type_from_events.rb
+++ b/db/migrate/20151125010131_delete_type_from_events.rb
@@ -1,4 +1,4 @@
-class DeleteTypeFromEvents < ActiveRecord::Migration
+class DeleteTypeFromEvents < ActiveRecord::Migration[5.1]
   def change
     remove_column :events, :type, :string
   end

--- a/db/migrate/20151125011253_create_members.rb
+++ b/db/migrate/20151125011253_create_members.rb
@@ -1,4 +1,4 @@
-class CreateMembers < ActiveRecord::Migration
+class CreateMembers < ActiveRecord::Migration[5.1]
   def change
     create_table :members do |t|
       t.string :name

--- a/db/migrate/20151125011825_create_news_items.rb
+++ b/db/migrate/20151125011825_create_news_items.rb
@@ -1,4 +1,4 @@
-class CreateNewsItems < ActiveRecord::Migration
+class CreateNewsItems < ActiveRecord::Migration[5.1]
   def up
     create_table :news_items do |t|
       t.string :state

--- a/db/migrate/20151125023733_rename_company_translation_to_organization_translation.rb
+++ b/db/migrate/20151125023733_rename_company_translation_to_organization_translation.rb
@@ -1,4 +1,4 @@
-class RenameCompanyTranslationToOrganizationTranslation < ActiveRecord::Migration
+class RenameCompanyTranslationToOrganizationTranslation < ActiveRecord::Migration[5.1]
   def change
     rename_table :company_translations, :organization_translations
     rename_column :organization_translations, :company_id, :organization_id

--- a/db/migrate/20151129215545_add_omniauth_to_users.rb
+++ b/db/migrate/20151129215545_add_omniauth_to_users.rb
@@ -1,4 +1,4 @@
-class AddOmniauthToUsers < ActiveRecord::Migration
+class AddOmniauthToUsers < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :provider, :string
     add_index :users, :provider

--- a/db/migrate/20151203012632_add_null_constraint_to_email.rb
+++ b/db/migrate/20151203012632_add_null_constraint_to_email.rb
@@ -1,4 +1,4 @@
-class AddNullConstraintToEmail < ActiveRecord::Migration
+class AddNullConstraintToEmail < ActiveRecord::Migration[5.1]
   def change
     change_column_null :members, :email, false
   end

--- a/db/migrate/20151203025820_add_admin_to_users.rb
+++ b/db/migrate/20151203025820_add_admin_to_users.rb
@@ -1,4 +1,4 @@
-class AddAdminToUsers < ActiveRecord::Migration
+class AddAdminToUsers < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :admin, :boolean, null: false, default: false
   end

--- a/db/migrate/20151203031902_add_foreign_key_to_users.rb
+++ b/db/migrate/20151203031902_add_foreign_key_to_users.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyToUsers < ActiveRecord::Migration
+class AddForeignKeyToUsers < ActiveRecord::Migration[5.1]
   def change
     add_column :users, :member_id, :integer
     add_foreign_key :users, :members

--- a/db/migrate/20151203085854_add_legacy_slug_to_news_item.rb
+++ b/db/migrate/20151203085854_add_legacy_slug_to_news_item.rb
@@ -1,4 +1,4 @@
-class AddLegacySlugToNewsItem < ActiveRecord::Migration
+class AddLegacySlugToNewsItem < ActiveRecord::Migration[5.1]
   def change
     add_column :news_items, :slug, :string
     add_index :news_items, :slug

--- a/db/migrate/20151204170038_make_locations_name_required.rb
+++ b/db/migrate/20151204170038_make_locations_name_required.rb
@@ -1,4 +1,4 @@
-class MakeLocationsNameRequired < ActiveRecord::Migration
+class MakeLocationsNameRequired < ActiveRecord::Migration[5.1]
   def up
     change_column :locations, :name, :string, null: false
   end

--- a/db/migrate/20151204172708_make_events_title_required.rb
+++ b/db/migrate/20151204172708_make_events_title_required.rb
@@ -1,4 +1,4 @@
-class MakeEventsTitleRequired < ActiveRecord::Migration
+class MakeEventsTitleRequired < ActiveRecord::Migration[5.1]
   def change
     change_column :event_translations, :title, :string, null: false
   end

--- a/db/migrate/20151204174632_make_events_location_id_required.rb
+++ b/db/migrate/20151204174632_make_events_location_id_required.rb
@@ -1,4 +1,4 @@
-class MakeEventsLocationIdRequired < ActiveRecord::Migration
+class MakeEventsLocationIdRequired < ActiveRecord::Migration[5.1]
   def up
     change_column :events, :location_id, :integer, null: false
   end

--- a/db/migrate/20151206020220_remove_foreign_key_from_users.rb
+++ b/db/migrate/20151206020220_remove_foreign_key_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveForeignKeyFromUsers < ActiveRecord::Migration
+class RemoveForeignKeyFromUsers < ActiveRecord::Migration[5.1]
   def change
     remove_foreign_key :users, :members
     remove_column :users, :member_id

--- a/db/migrate/20151206044801_remove_introduction_conclusion_from_event.rb
+++ b/db/migrate/20151206044801_remove_introduction_conclusion_from_event.rb
@@ -1,4 +1,4 @@
-class RemoveIntroductionConclusionFromEvent < ActiveRecord::Migration
+class RemoveIntroductionConclusionFromEvent < ActiveRecord::Migration[5.1]
   def change
     remove_column :event_translations, :introduction, :text
     remove_column :event_translations, :conclusion, :text

--- a/db/migrate/20151206044852_add_foreign_key_to_members.rb
+++ b/db/migrate/20151206044852_add_foreign_key_to_members.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyToMembers < ActiveRecord::Migration
+class AddForeignKeyToMembers < ActiveRecord::Migration[5.1]
   def change
     add_column :members, :user_id, :integer
     add_foreign_key :members, :users

--- a/db/migrate/20151206045102_add_body_to_event.rb
+++ b/db/migrate/20151206045102_add_body_to_event.rb
@@ -1,4 +1,4 @@
-class AddBodyToEvent < ActiveRecord::Migration
+class AddBodyToEvent < ActiveRecord::Migration[5.1]
   def up
     Event.add_translation_fields! body: :text
   end

--- a/db/migrate/20151209033612_create_talks.rb
+++ b/db/migrate/20151209033612_create_talks.rb
@@ -1,4 +1,4 @@
-class CreateTalks < ActiveRecord::Migration
+class CreateTalks < ActiveRecord::Migration[5.1]
   def up
     create_table :talks do |t|
       t.string :state

--- a/db/migrate/20151209201426_add_user_id_to_some_models.rb
+++ b/db/migrate/20151209201426_add_user_id_to_some_models.rb
@@ -1,4 +1,4 @@
-class AddUserIdToSomeModels < ActiveRecord::Migration
+class AddUserIdToSomeModels < ActiveRecord::Migration[5.1]
   def up
 
     User.create_default_user! if User.default_user.blank?

--- a/db/migrate/20151213183525_create_friendly_id_slugs.rb
+++ b/db/migrate/20151213183525_create_friendly_id_slugs.rb
@@ -1,4 +1,4 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]
   def change
     create_table :friendly_id_slugs do |t|
       t.string :slug, null: false

--- a/db/migrate/20151213185304_add_slug_to_page.rb
+++ b/db/migrate/20151213185304_add_slug_to_page.rb
@@ -1,4 +1,4 @@
-class AddSlugToPage < ActiveRecord::Migration
+class AddSlugToPage < ActiveRecord::Migration[5.1]
   def change
     add_column :pages, :slug, :string, null: false, default: 'temporary-slug'
 

--- a/db/migrate/20160308004823_add_state_to_events.rb
+++ b/db/migrate/20160308004823_add_state_to_events.rb
@@ -1,4 +1,4 @@
-class AddStateToEvents < ActiveRecord::Migration
+class AddStateToEvents < ActiveRecord::Migration[5.1]
   def change
     add_column :events, :state, :string, default: "proposed"
   end

--- a/db/migrate/20160310032356_create_habtm_relationship_between_members_and_events.rb
+++ b/db/migrate/20160310032356_create_habtm_relationship_between_members_and_events.rb
@@ -1,4 +1,4 @@
-class CreateHabtmRelationshipBetweenMembersAndEvents < ActiveRecord::Migration
+class CreateHabtmRelationshipBetweenMembersAndEvents < ActiveRecord::Migration[5.1]
   def change
     create_table :events_members do |t|
       t.belongs_to :event,  index: true

--- a/db/migrate/20160310032845_habtm_relationship_between_members_and_organization.rb
+++ b/db/migrate/20160310032845_habtm_relationship_between_members_and_organization.rb
@@ -1,4 +1,4 @@
-class HabtmRelationshipBetweenMembersAndOrganization < ActiveRecord::Migration
+class HabtmRelationshipBetweenMembersAndOrganization < ActiveRecord::Migration[5.1]
   def change
     create_table :members_organizations do |t|
       t.belongs_to :organization,  index: true

--- a/db/migrate/20160317171203_create_sponsorships.rb
+++ b/db/migrate/20160317171203_create_sponsorships.rb
@@ -1,4 +1,4 @@
-class CreateSponsorships < ActiveRecord::Migration
+class CreateSponsorships < ActiveRecord::Migration[5.1]
   def change
     create_table :sponsorships do |t|
       t.references :event, index: true, foreign_key: true, null: false

--- a/db/migrate/20160317214951_add_member_to_talk.rb
+++ b/db/migrate/20160317214951_add_member_to_talk.rb
@@ -1,4 +1,4 @@
-class AddMemberToTalk < ActiveRecord::Migration
+class AddMemberToTalk < ActiveRecord::Migration[5.1]
   def change
     add_reference :talks, :member, index: true
   end

--- a/db/migrate/20160318004322_change_picture_type.rb
+++ b/db/migrate/20160318004322_change_picture_type.rb
@@ -1,4 +1,4 @@
-class ChangePictureType < ActiveRecord::Migration
+class ChangePictureType < ActiveRecord::Migration[5.1]
   def change
     change_column :members, :picture, :string
   end

--- a/db/migrate/20160424005454_add_message_to_sponsorship.rb
+++ b/db/migrate/20160424005454_add_message_to_sponsorship.rb
@@ -1,4 +1,4 @@
-class AddMessageToSponsorship < ActiveRecord::Migration
+class AddMessageToSponsorship < ActiveRecord::Migration[5.1]
   def change
     add_column :sponsorships, :message, :string
   end

--- a/db/migrate/20170316013002_add_counter_cache_to_events_association.rb
+++ b/db/migrate/20170316013002_add_counter_cache_to_events_association.rb
@@ -1,4 +1,4 @@
-class AddCounterCacheToEventsAssociation < ActiveRecord::Migration
+class AddCounterCacheToEventsAssociation < ActiveRecord::Migration[5.1]
   def change
     add_column :events, :talks_count, :integer, :default => 0
     add_column :events, :sponsorships_count, :integer, :default => 0

--- a/db/migrate/20170316030731_add_fields_to_member.rb
+++ b/db/migrate/20170316030731_add_fields_to_member.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddFieldsToMember < ActiveRecord::Migration
+class AddFieldsToMember < ActiveRecord::Migration[5.1]
   def change
     add_column :members, :website, :string
     add_column :members, :company, :string

--- a/db/migrate/20170325032903_add_format_to_talk.rb
+++ b/db/migrate/20170325032903_add_format_to_talk.rb
@@ -1,4 +1,4 @@
-class AddFormatToTalk < ActiveRecord::Migration
+class AddFormatToTalk < ActiveRecord::Migration[5.1]
   def change
     add_column :talks, :format, :string, nil: false
     Talk.find_each do |talk|

--- a/db/migrate/20170523223432_create_contacts.rb
+++ b/db/migrate/20170523223432_create_contacts.rb
@@ -1,4 +1,4 @@
-class CreateContacts < ActiveRecord::Migration
+class CreateContacts < ActiveRecord::Migration[5.1]
   def change
     create_table :contacts do |t|
       t.string :name

--- a/db/migrate/20170523233820_add_user_to_contacts.rb
+++ b/db/migrate/20170523233820_add_user_to_contacts.rb
@@ -1,4 +1,4 @@
-class AddUserToContacts < ActiveRecord::Migration
+class AddUserToContacts < ActiveRecord::Migration[5.1]
   def change
     add_reference :contacts, :user, index: true, foreign_key: true
   end

--- a/db/migrate/20170524022609_add_published_at_to_jobs.rb
+++ b/db/migrate/20170524022609_add_published_at_to_jobs.rb
@@ -1,4 +1,4 @@
-class AddPublishedAtToJobs < ActiveRecord::Migration
+class AddPublishedAtToJobs < ActiveRecord::Migration[5.1]
   def change
     add_column :jobs, :published_at, :datetime
   end


### PR DESCRIPTION
Running `rails db:migrate` raises an error saying that directly inheriting from ActiveRecord::Migration
is not supported. To fix this, I added the rails version for all migrations to be 5.1