### PR TITLE
Bugfix require factory_bot_rails

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "factory_girl_rails"
+require "factory_bot_rails"
 
 FactoryBot.create(:user, email: "user@example.com", password: "password")
 FactoryBot.create(:user, :admin, email: "admin@example.com", password: "password")


### PR DESCRIPTION
Change was missed when we bumped to the new gem name (factory_girl_rails to factory_bot_rails).

Note: I didn't add a test as this deals with setup code.