### PR TITLE
Removing invalid gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Montreal.rb website
 
 [![Build Status](https://travis-ci.org/montrealrb/Montreal.rb.svg)](https://travis-ci.org/montrealrb/Montreal.rb)
-[![Dependency Status](https://gemnasium.com/montrealrb/Montreal.rb.svg)](https://gemnasium.com/montrealrb/Montreal.rb)
 [![Code Climate](https://codeclimate.com/github/montrealrb/Montreal.rb/badges/gpa.svg)](https://codeclimate.com/github/montrealrb/Montreal.rb)
 [![Stories in Priority](https://badge.waffle.io/montrealrb/Montreal.rb.svg?label=priority&title=Priority)](http://waffle.io/montrealrb/Montreal.rb)
 


### PR DESCRIPTION
Gemnasium is closed for GH projects, see https://docs.gitlab.com/ee/user/project/import/gemnasium.html for further explanation